### PR TITLE
Fixed typo, added namespace doc & Cake upgrade

### DIFF
--- a/src/ElasticLoadBalancing/Aliases/LoadBalancingAliases.cs
+++ b/src/ElasticLoadBalancing/Aliases/LoadBalancingAliases.cs
@@ -13,6 +13,9 @@
 
 namespace Cake.AWS.ElasticLoadBalancing
 {
+    /// <summary>
+    /// Contains Cake aliases for configuring Amazon Elastic Load Balancers
+    /// </summary>
     [CakeAliasCategory("AWS")]
     [CakeNamespaceImport("Amazon")]
     [CakeNamespaceImport("Amazon.ElasticLoadBalancing")]

--- a/src/ElasticLoadBalancing/Cake.AWS.ElasticLoadBalancing.csproj
+++ b/src/ElasticLoadBalancing/Cake.AWS.ElasticLoadBalancing.csproj
@@ -41,8 +41,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\AWSSDK.ElasticLoadBalancing.dll</HintPath>
     </Reference>
-    <Reference Include="Cake.Core">
-      <HintPath>..\packages\Cake.Core.0.4.1\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.6.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.6.3\lib\net45\Cake.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -60,6 +61,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Manager\LoadBalancingManager.cs" />
     <Compile Include="Properties\SolutionInfo.cs" />
+    <Compile Include="Properties\Namespaces.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/ElasticLoadBalancing/Manager/LoadBalancingManager.cs
+++ b/src/ElasticLoadBalancing/Manager/LoadBalancingManager.cs
@@ -129,7 +129,7 @@ namespace Cake.AWS.ElasticLoadBalancing
                 }
                 else
                 {
-                    _Log.Error("Failed to registere instances '{0}'", string.Join(",", instances));
+                    _Log.Error("Failed to register instances '{0}'", string.Join(",", instances));
                     return false;
                 }
             }

--- a/src/ElasticLoadBalancing/Properties/Namespaces.cs
+++ b/src/ElasticLoadBalancing/Properties/Namespaces.cs
@@ -1,0 +1,14 @@
+using System.Runtime.CompilerServices;
+// ReSharper disable CheckNamespace
+
+
+namespace Cake.AWS.ElasticLoadBalancing
+{
+    /// <summary>
+    /// This namespace contains elastic load balancing aliases and related members.
+    /// </summary>
+    [CompilerGenerated]
+    internal class NamespaceDoc
+    {
+    }
+}

--- a/src/ElasticLoadBalancing/Settings/LoadBalancingSettings.cs
+++ b/src/ElasticLoadBalancing/Settings/LoadBalancingSettings.cs
@@ -9,7 +9,7 @@
 namespace Cake.AWS.ElasticLoadBalancing
 {
     /// <summary>
-    /// The settings to use with downlad requests to Amazon ElasticLoadBalancing
+    /// The settings to use with download requests to Amazon ElasticLoadBalancing
     /// </summary>
     public class LoadBalancingSettings
     {
@@ -37,8 +37,6 @@ namespace Cake.AWS.ElasticLoadBalancing
             /// The AWS Secret Access Key.
             /// </summary>
             public string SecretKey { get; set; }
-
-
 
             /// <summary>
             /// The endpoints available to AWS clients.

--- a/src/ElasticLoadBalancing/packages.config
+++ b/src/ElasticLoadBalancing/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.4.1" targetFramework="net45" />
+  <package id="Cake.Core" version="0.6.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Found some minor typos in docs / literals
- Added Cake non standard namespace docs
- Upgraded and built against lates released Cake (0.6.3)
